### PR TITLE
Docker health-check

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,10 @@ services:
             - MYSQL_DATABASE=magento
             - MYSQL_USER=magento
             - MYSQL_PASSWORD=magento
+        healthcheck:
+            test: mysql --user=root --password=SuperSecret -e 'SELECT * FROM INFORMATION_SCHEMA.TABLES;'
+            timeout: 20s
+            retries: 10
     php:
         image: 'b2b_magento2/php'
         build:
@@ -32,7 +36,8 @@ services:
             - M2SETUP_FORCE_EXECUTION=true
             - M2MODE=developer
         depends_on:
-            - "mysql"
+            "mysql":
+                condition: service_healthy
     nginx:
         image: 'b2b_magento2/nginx'
         build:
@@ -44,6 +49,7 @@ services:
         volumes_from:
             - php:ro
         depends_on:
-            - "php"
+            "php":
+                 condition: service_started
 volumes:
   mysqldb_data:


### PR DESCRIPTION
In this Pull Request we included a docker health check that causes a delay in the php container initialization. 

The fix guarantees that the php container will just start his initialization after the mysql container is up, running and accepting connections for their clients. 

It avoids Magento setup problems during the php container startup