### PR TITLE
Docker build separation concerns

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,8 @@ services:
             - M2SETUP_USE_SAMPLE_DATA=false
             - M2SETUP_FORCE_EXECUTION=true
             - M2MODE=developer
+        volumes:
+            - ~/.composer/auth.json:/root/.composer/auth.json
         depends_on:
             "mysql":
                 condition: service_healthy

--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -1,9 +1,6 @@
 FROM php:7.0-fpm
 
-ADD log.conf /usr/local/etc/php-fpm.d/zz-log.conf
-
-RUN apt-get update \
-  && apt-get install -y \
+RUN apt-get update  && apt-get install -y \
     cron \
     libfreetype6-dev \
     libicu-dev \
@@ -12,8 +9,7 @@ RUN apt-get update \
     libpng12-dev \
     libxslt1-dev
 
-RUN docker-php-ext-configure \
-  gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/
+RUN docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/
 
 RUN docker-php-ext-install \
   gd \
@@ -28,6 +24,15 @@ RUN docker-php-ext-install \
 
 RUN pecl install xdebug-stable
 
+RUN curl -sS https://getcomposer.org/installer | \
+    php -- \
+      --install-dir=/usr/local/bin \
+      --filename=composer \
+      --version=1.3.0
+
+RUN echo "php_admin_flag[log_errors] = on" > /usr/local/etc/php-fpm.d/zz-log.conf && \
+    echo "php_flag[display_errors] = off" >> /usr/local/etc/php-fpm.d/zz-log.conf
+
 RUN echo "zend_extension=/usr/local/lib/php/extensions/no-debug-non-zts-20151012/xdebug.so" > /usr/local/etc/php/conf.d/xdebug.ini && \
     echo "xdebug.default_enable = 1" >> /usr/local/etc/php/conf.d/xdebug.ini && \
     echo "xdebug.remote_enable = 1" >> /usr/local/etc/php/conf.d/xdebug.ini && \
@@ -40,26 +45,15 @@ RUN echo "zend_extension=/usr/local/lib/php/extensions/no-debug-non-zts-20151012
     echo "xdebug.profiler_enable_trigger=1" >> /usr/local/etc/php/conf.d/xdebug.ini && \
     echo "xdebug.profiler_output_dir=\"/tmp\"" >> /usr/local/etc/php/conf.d/xdebug.ini
 
-RUN curl -sS https://getcomposer.org/installer | \
-    php -- \
-      --install-dir=/usr/local/bin \
-      --filename=composer \
-      --version=1.3.0
-
-COPY auth.json /root/.composer/auth.json
-
-# # Install Magento project
-RUN composer create-project \
-  --repository-url=https://repo.magento.com/ \
-  magento/project-enterprise-edition=2.1.7 \
-  /src
+COPY ./php.ini /usr/local/etc/php/php.ini
+COPY ./run.sh /usr/local/bin/
+COPY ./m2setup.sh /usr/local/bin/
+COPY ./magento-create-project.sh /usr/local/bin/
+COPY ./magento-set-permissions.sh /usr/local/bin/
 
 WORKDIR /src
 
 VOLUME /src
-
-COPY php.ini /usr/local/etc/php/php.ini
-COPY ./run.sh /usr/local/bin/
-COPY ./m2setup.sh /usr/local/bin/
+VOLUME /root/.composer
 
 CMD ["/usr/local/bin/run.sh"]

--- a/php/log.conf
+++ b/php/log.conf
@@ -1,2 +1,0 @@
-php_admin_flag[log_errors] = on
-php_flag[display_errors] = off

--- a/php/magento-create-project.sh
+++ b/php/magento-create-project.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+if [ "$#" -ne 1 ]; then
+    echo "Illegal number of parameters"
+    exit 1
+fi
+
+targetdir=$1
+if [ ! -f "$targetdir/composer.json" ]; then 
+  echo "No composer.json found on $targetdir. Creating a new one with 'composer create-project'"
+  composer create-project \
+    --repository-url=https://repo.magento.com/ \
+    magento/project-enterprise-edition=2.1.7 \
+    $targetdir
+  exit 0
+fi
+
+echo "There is a project already created on $targetdir. Nothing to do."

--- a/php/magento-set-permissions.sh
+++ b/php/magento-set-permissions.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+targetdir=$1
+
+echo "Set permissions for shared hosting (one user)"
+find $targetdir/var $targetdir/vendor $targetdir/pub/static $targetdir/pub/media $targetdir/app/etc -type f -exec chmod u+w {} \;
+find $targetdir/var $targetdir/vendor $targetdir/pub/static $targetdir/pub/media $targetdir/app/etc -type d -exec chmod u+w {} \;
+chmod u+x $targetdir/bin/magento


### PR DESCRIPTION
In this Pull Request I refactored the setup scripts and Dockerfile to bring a separation of concerns:
- Dockerfile is responsible for build de infra-structure needed to run Magento (php, plugins, volumes, etc)
- The entrypoint bash scripts is responsible for download, install and configure magento properly. They were divided in many small scripts to providie some reuse for the extensions. 

In this model, I'm also suggesting to solve the `auth.json` problem as a **docker volume** in docker-compose.yml. The first container initialization became slower, but is just the first one. The scripts are instrumented to discover if the install has done once and skip it.